### PR TITLE
Issue#1-counts in readers.py are fixed

### DIFF
--- a/libary.py
+++ b/libary.py
@@ -160,7 +160,7 @@ class Library:
         reader_found = False
         for reader in self.__readers:
             if reader.get_id() == reader_id:
-                if len(reader.get_borrowed_books()) >= reader.get_books_count():
+                if len(reader.get_borrowed_books()) >= 5 :
                     print(f" Czytelnik wypozyczyl juz maksymalna ilość ksiazek.")
                     return
                 reader_found = True
@@ -193,7 +193,7 @@ class Library:
         for reader in self.__readers:
             if reader.get_id() == reader_id:
                 reader.add_borrowed_book(title)
-                reader.decrease_books_count()
+                reader.increase_books_count()
                 break
 
         self.__save_books_to_file()
@@ -215,7 +215,7 @@ class Library:
             if reader.get_id() == reader_id:
                 if title in reader.get_borrowed_books():
                     reader.remove_borrowed_book(title)
-                    reader.increase_books_count()
+                    reader.decrease_books_count()
                 else:
                     print(f" Czytelnik nie ma wypozyczonej ksiazki o tytule {title}.")
                     return


### PR DESCRIPTION
Fix for https://github.com/Shift-Happens/digital_text_libary/issues/1

The counters in readers.csv are working fine now.
Status after reader 1 and 2 borrows a book and reader 2 returns his book.
<img width="505" alt="Screenshot 2023-06-07 at 7 36 19 PM" src="https://github.com/Shift-Happens/digital_text_libary/assets/10849962/27815037-d5bc-4d62-859e-7c88f0de6bfa">

Made a hardcode of 5 in the below area. This is because, with the condition you kept 
`if len(reader.get_borrowed_books()) >= reader.get_books_count():` the use can never borrow second time. Hence I kept a cap of 5 saying a reader can at max borrow 5 books.

<img width="592" alt="Screenshot 2023-06-07 at 7 40 54 PM" src="https://github.com/Shift-Happens/digital_text_libary/assets/10849962/75d5e7c8-aad2-44ab-bf7f-f84b2da5cb29">


Let me know your thoughts :)